### PR TITLE
STYLE: Replace itkTypeMacro calls with `itkOverrideGetNameOfClassMacro`

### DIFF
--- a/include/itkCudaDataManager.h
+++ b/include/itkCudaDataManager.h
@@ -41,7 +41,11 @@ public:
   using ConstPointer = SmartPointer<const Self>;
 
   itkNewMacro(Self);
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(GPUMemPointer);
+#else
   itkTypeMacro(GPUMemPointer, Object);
+#endif
 
   void
   Allocate(size_t bufferSize)
@@ -131,7 +135,11 @@ public:
   using ModifiedTimeType = unsigned long;
 
   itkNewMacro(Self);
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(CudaDataManager);
+#else
   itkTypeMacro(CudaDataManager, Object);
+#endif
 
   /** total buffer size in bytes */
   void

--- a/include/itkCudaImage.h
+++ b/include/itkCudaImage.h
@@ -48,7 +48,11 @@ public:
 
   itkNewMacro(Self);
 
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(CudaImage);
+#else
   itkTypeMacro(CudaImage, Image);
+#endif
 
   static constexpr unsigned int ImageDimension = VImageDimension;
 
@@ -245,7 +249,11 @@ public:
   itkFactorylessNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(CudaImageFactory);
+#else
   itkTypeMacro(CudaImageFactory, itk::ObjectFactoryBase);
+#endif
 
   /** Register one factory of this type  */
   static void

--- a/include/itkCudaImageDataManager.h
+++ b/include/itkCudaImageDataManager.h
@@ -49,7 +49,11 @@ public:
   using SizeType = typename ImageType::SizeType;
 
   itkNewMacro(Self);
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(CudaImageDataManager);
+#else
   itkTypeMacro(CudaImageDataManager, CudaDataManager);
+#endif
 
   itkGetModifiableObjectMacro(GPUBufferedRegionIndex, CudaDataManager);
   itkGetModifiableObjectMacro(GPUBufferedRegionSize, CudaDataManager);

--- a/include/itkCudaImageToImageFilter.h
+++ b/include/itkCudaImageToImageFilter.h
@@ -51,7 +51,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(CudaImageToImageFilter);
+#else
   itkTypeMacro(CudaImageToImageFilter, TParentImageFilter);
+#endif
 
   /** Superclass type alias. */
   using DataObjectIdentifierType = typename Superclass::DataObjectIdentifierType;

--- a/include/itkCudaInPlaceImageFilter.h
+++ b/include/itkCudaInPlaceImageFilter.h
@@ -47,7 +47,11 @@ public:
   using ConstPointer = SmartPointer<const Self>;
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(CudaInPlaceImageFilter);
+#else
   itkTypeMacro(CudaInPlaceImageFilter, CudaImageToImageFilter);
+#endif
 
   /** Superclass type alias. */
   using OutputImageType = typename GPUSuperclass::OutputImageType;

--- a/include/itkCudaSquareImageFilter.h
+++ b/include/itkCudaSquareImageFilter.h
@@ -45,7 +45,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(CudaSquareImageFilter);
+#else
   itkTypeMacro(CudaSquareImageFilter, CudaImageToImageFilter);
+#endif
 
   ITK_DISALLOW_COPY_AND_MOVE(CudaSquareImageFilter);
 


### PR DESCRIPTION
Follows
InsightSoftwareConsortium/ITK@2c264ea2ef62e916c6ef947599ce659cc8fce5fe