### PR TITLE
STYLE: Clean-up itkTypeMacro kept for backward compatibility

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,4 @@
-## This config file is only relevant for clang-format version 8.0.0
+## This config file is only relevant for clang-format version 19.1.4
 ##
 ## Examples of each format style can be found on the in the clang-format documentation
 ## See: https://clang.llvm.org/docs/ClangFormatStyleOptions.html for details of each option
@@ -10,142 +10,309 @@
 ## maintaining a consistent code style.
 ##
 ## EXAMPLE apply code style enforcement before commit:
-#     Utilities/Maintenance/clang-format.bash --clang ${PATH_TO_CLANG_FORMAT_8.0.0} --modified
+#     Utilities/Maintenance/clang-format.bash --clang ${PATH_TO_CLANG_FORMAT_19.1.4} --modified
 ## EXAMPLE apply code style enforcement after commit:
-#     Utilities/Maintenance/clang-format.bash --clang ${PATH_TO_CLANG_FORMAT_8.0.0} --last
+#     Utilities/Maintenance/clang-format.bash --clang ${PATH_TO_CLANG_FORMAT_19.1.4} --last
 ---
-# This configuration requires clang-format version 8.0.0 exactly.
-BasedOnStyle: Mozilla
+# This configuration requires clang-format version 19.1.4 exactly.
 Language:        Cpp
 AccessModifierOffset: -2
 AlignAfterOpenBracket: Align
-AlignConsecutiveAssignments: false
-AlignConsecutiveDeclarations: true
-AlignEscapedNewlines: Right
-AlignOperands:   true
-AlignTrailingComments: true
-# clang 9.0 AllowAllArgumentsOnNextLine: true
-# clang 9.0 AllowAllConstructorInitializersOnNextLine: true
+AlignArrayOfStructures: None
+AlignConsecutiveAssignments:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    true
+AlignConsecutiveBitFields:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveDeclarations:
+  Enabled:         true
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    true
+AlignConsecutiveMacros:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveShortCaseStatements:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCaseArrows: false
+  AlignCaseColons: false
+AlignConsecutiveTableGenBreakingDAGArgColons:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveTableGenCondOperatorColons:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveTableGenDefinitionColons:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignEscapedNewlines: Left
+AlignOperands:   Align
+AlignTrailingComments:
+  Kind:            Always
+  OverEmptyLines:  0
+AllowAllArgumentsOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: false
-AllowShortBlocksOnASingleLine: false
+AllowBreakBeforeNoexceptSpecifier: Never
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseExpressionOnASingleLine: true
 AllowShortCaseLabelsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: Inline
-# clang 9.0 AllowShortLambdasOnASingleLine: All
-# clang 9.0 features AllowShortIfStatementsOnASingleLine: Never
-AllowShortIfStatementsOnASingleLine: false
+AllowShortCompoundRequirementOnASingleLine: true
+AllowShortEnumsOnASingleLine: true
+#AllowShortFunctionsOnASingleLine: Inline Only merge functions defined inside a class. Implies empty.
+#AllowShortFunctionsOnASingleLine: None (in configuration: None) Never merge functions into a single line.
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: All
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: None
-AlwaysBreakAfterReturnType: All
 AlwaysBreakBeforeMultilineStrings: false
-AlwaysBreakTemplateDeclarations: Yes
+AttributeMacros:
+  - __capability
 BinPackArguments: false
 BinPackParameters: false
-BreakBeforeBraces: Custom
+BitFieldColonSpacing: Both
 BraceWrapping:
-  # clang 9.0 feature AfterCaseLabel:  false
+  AfterCaseLabel:  true
   AfterClass:      true
-  AfterControlStatement: true
+  AfterControlStatement: Always
   AfterEnum:       true
+  AfterExternBlock: true
   AfterFunction:   true
   AfterNamespace:  true
   AfterObjCDeclaration: true
   AfterStruct:     true
   AfterUnion:      true
-  AfterExternBlock: true
   BeforeCatch:     true
   BeforeElse:      true
-## This is the big change from historical ITK formatting!
-# Historically ITK used a style similar to https://en.wikipedia.org/wiki/Indentation_style#Whitesmiths_style
-# with indented braces, and not indented code.  This style is very difficult to automatically
-# maintain with code beautification tools.  Not indenting braces is more common among
-# formatting tools.
+  BeforeLambdaBody: false
+  BeforeWhile:     false
   IndentBraces:    false
   SplitEmptyFunction: false
   SplitEmptyRecord: false
   SplitEmptyNamespace: false
-BreakBeforeBinaryOperators: None
-#clang 6.0 BreakBeforeInheritanceComma: true
-BreakInheritanceList: BeforeComma
-BreakBeforeTernaryOperators: true
-#clang 6.0 BreakConstructorInitializersBeforeComma: true
-BreakConstructorInitializers: BeforeComma
+BreakAdjacentStringLiterals: true
+BreakAfterAttributes: Leave
 BreakAfterJavaFieldAnnotations: false
+BreakAfterReturnType: All
+BreakArrays:     true
+BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: Always
+BreakBeforeBraces: Custom
+BreakBeforeInlineASMColon: OnlyMultiline
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeComma
+BreakFunctionDefinitionParameters: false
+BreakInheritanceList: BeforeComma
 BreakStringLiterals: true
+BreakTemplateDeclarations: Yes
 ## The following line allows larger lines in non-documentation code
 ColumnLimit:     120
 CommentPragmas:  '^ IWYU pragma:'
 CompactNamespaces: false
-ConstructorInitializerAllOnOneLineOrOnePerLine: false
 ConstructorInitializerIndentWidth: 2
 ContinuationIndentWidth: 2
 Cpp11BracedListStyle: false
 DerivePointerAlignment: false
 DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
 ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: true
 ForEachMacros:
   - foreach
   - Q_FOREACH
   - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
 IncludeBlocks:   Preserve
 IncludeCategories:
   - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
     Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
   - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
     Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
   - Regex:           '.*'
     Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
 IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseBlocks: false
 IndentCaseLabels: true
+IndentExternBlock: AfterExternBlock
+IndentGotoLabels: true
 IndentPPDirectives: AfterHash
+IndentRequiresClause: true
 IndentWidth:     2
 IndentWrappedFunctionNames: false
+InsertBraces:    false
+InsertNewlineAtEOF: false
+InsertTrailingCommas: None
+IntegerLiteralSeparator:
+  Binary:          0
+  BinaryMinDigits: 0
+  Decimal:         0
+  DecimalMinDigits: 0
+  Hex:             0
+  HexMinDigits:    0
 JavaScriptQuotes: Leave
 JavaScriptWrapImports: true
-KeepEmptyLinesAtTheStartOfBlocks: true
+KeepEmptyLines:
+  AtEndOfFile:     false
+  AtStartOfBlock:  true
+  AtStartOfFile:   true
+LambdaBodyIndentation: Signature
+LineEnding:      DeriveLF
 MacroBlockBegin: ''
 MacroBlockEnd:   ''
+MainIncludeChar: Quote
 MaxEmptyLinesToKeep: 2
 NamespaceIndentation: None
 ObjCBinPackProtocolList: Auto
 ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
 ObjCSpaceAfterProperty: true
 ObjCSpaceBeforeProtocolList: false
+PackConstructorInitializers: BinPack
 PenaltyBreakAssignment: 2
 PenaltyBreakBeforeFirstCallParameter: 19
 PenaltyBreakComment: 300
 ## The following line allows larger lines in non-documentation code
 PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakScopeResolution: 500
 PenaltyBreakString: 1000
 PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
+PenaltyIndentedWhitespace: 0
 PenaltyReturnTypeOnItsOwnLine: 200
 PointerAlignment: Middle
+PPIndentWidth:   -1
+QualifierAlignment: Custom
+QualifierOrder:
+  - friend
+  - static
+  - inline
+  - constexpr
+  - const
+  - type
+ReferenceAlignment: Pointer
 ReflowComments:  true
+RemoveBracesLLVM: false
+RemoveParentheses: Leave
+RemoveSemicolon: false
+RequiresClausePosition: OwnLine
+RequiresExpressionIndentation: OuterScope
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SkipMacroDefinitionBody: false
 # We may want to sort the includes as a separate pass
-SortIncludes:    false
+SortIncludes:    Never
+SortJavaStaticImport: Before
 # We may want to revisit this later
-SortUsingDeclarations: false
+SortUsingDeclarations: Never
 SpaceAfterCStyleCast: false
-# SpaceAfterLogicalNot: false
+SpaceAfterLogicalNot: false
 SpaceAfterTemplateKeyword: true
+SpaceAroundPointerQualifiers: Default
 SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
 SpaceBeforeCpp11BracedList: false
 SpaceBeforeCtorInitializerColon: true
 SpaceBeforeInheritanceColon: true
+SpaceBeforeJsonColon: false
 SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  AfterPlacementOperator: true
+  AfterRequiresInClause: false
+  AfterRequiresInExpression: false
+  BeforeNonEmptyParentheses: false
 SpaceBeforeRangeBasedForLoopColon: true
-SpaceInEmptyParentheses: false
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
 SpacesBeforeTrailingComments: 1
-SpacesInAngles:  false
+SpacesInAngles:  Never
 SpacesInContainerLiterals: false
-SpacesInCStyleCastParentheses: false
-SpacesInParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParens:  Never
+SpacesInParensOptions:
+  ExceptDoubleParentheses: false
+  InCStyleCasts:   false
+  InConditionalStatements: false
+  InEmptyParentheses: false
+  Other:           false
 SpacesInSquareBrackets: false
-Standard:        Cpp11
+Standard:        Latest
+StatementAttributeLikeMacros:
+  - Q_EMIT
 StatementMacros:
   - Q_UNUSED
   - QT_REQUIRE_VERSION
+  - ITK_GCC_PRAGMA_PUSH
+  - ITK_GCC_PRAGMA_POP
+  - ITK_GCC_SUPPRESS_Wfloat_equal
+  - ITK_GCC_SUPPRESS_Wformat_nonliteral
+  - ITK_GCC_SUPPRESS_Warray_bounds
+  - ITK_CLANG_PRAGMA_PUSH
+  - ITK_CLANG_PRAGMA_POP
+  - ITK_CLANG_SUPPRESS_Wzero_as_null_pointer_constant
+  - CLANG_PRAGMA_PUSH
+  - CLANG_PRAGMA_POP
+  - CLANG_SUPPRESS_Wfloat_equal
+  - INTEL_PRAGMA_WARN_PUSH
+  - INTEL_PRAGMA_WARN_POP
+  - INTEL_SUPPRESS_warning_1292
+  - itkTemplateFloatingToIntegerMacro
+  - itkLegacyMacro
+TableGenBreakInsideDAGArg: DontBreak
 TabWidth:        2
 UseTab:          Never
+VerilogBreakBetweenInstancePorts: true
+WhitespaceSensitiveMacros:
+  - BOOST_PP_STRINGIZE
+  - CF_SWIFT_NAME
+  - NS_SWIFT_NAME
+  - PP_STRINGIZE
+  - STRINGIZE
 ...

--- a/.github/workflows/build-test-cxx-cuda.yml
+++ b/.github/workflows/build-test-cxx-cuda.yml
@@ -5,6 +5,10 @@ on: [push,pull_request]
 env:
   itk-git-tag: "v5.4.0"
 
+concurrency:
+  group: '${{ github.workflow }}@${{ github.head_ref || github.run_id }}'
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build-test-cxx:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build-test-package-python-cuda.yml
+++ b/.github/workflows/build-test-package-python-cuda.yml
@@ -90,7 +90,7 @@ jobs:
         /home/srit/miniconda3/envs/py310/bin/python -m twine check ${WHEEL_PATTERN}
 
     - name: Publish Python package as GitHub Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: LinuxWheel3${{ matrix.python3-minor-version }}${{ matrix.manylinux-platform }}-cuda${{ matrix.cuda-version }}
         path: dist/*.whl

--- a/.github/workflows/build-test-package-python-cuda.yml
+++ b/.github/workflows/build-test-package-python-cuda.yml
@@ -4,8 +4,8 @@ on: [push,pull_request]
 
 env:
   itk-wheel-tag: 'v5.4.0'
-  itk-python-package-tag: 'f38e8b0f38580807809b0412235fb2ba0946deba'
-  itk-python-package-org: 'InsightSoftwareConsortium'
+  itk-python-package-tag: '45cfd02a22661731ca5b155f210cfa2f887d50e7'
+  itk-python-package-org: 'SimonRit'
 
 concurrency:
   group: '${{ github.workflow }}@${{ github.head_ref || github.run_id }}'
@@ -17,7 +17,7 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        python3-minor-version: ["8","9","10","11"]
+        python3-minor-version: ${{ github.event_name == 'pull_request' && fromJSON('["11"]') || fromJSON('["9","10","11"]') }}
         manylinux-platform: ["_2_28-x64","2014-x64"]
         cuda-version: ["116","121"]
 
@@ -100,7 +100,7 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        python3-minor-version: ["8","9","10","11"]
+        python3-minor-version: ${{ github.event_name == 'pull_request' && fromJSON('["11"]') || fromJSON('["9","10","11"]') }}
         cuda-version: ["116","121"]
 
     steps:

--- a/.github/workflows/build-test-package-python-cuda.yml
+++ b/.github/workflows/build-test-package-python-cuda.yml
@@ -7,6 +7,10 @@ env:
   itk-python-package-tag: 'f38e8b0f38580807809b0412235fb2ba0946deba'
   itk-python-package-org: 'InsightSoftwareConsortium'
 
+concurrency:
+  group: '${{ github.workflow }}@${{ github.head_ref || github.run_id }}'
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build-linux-cuda-python-packages:
     runs-on: self-hosted-linux

--- a/.github/workflows/clang-format-linter.yml
+++ b/.github/workflows/clang-format-linter.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: InsightSoftwareConsortium/ITKClangFormatLinterAction@master
+      with:
+        itk-branch: master

--- a/include/itkCudaDataManager.h
+++ b/include/itkCudaDataManager.h
@@ -40,11 +40,7 @@ public:
   using ConstPointer = SmartPointer<const Self>;
 
   itkNewMacro(Self);
-#ifdef itkOverrideGetNameOfClassMacro
   itkOverrideGetNameOfClassMacro(GPUMemPointer);
-#else
-  itkTypeMacro(GPUMemPointer, Object);
-#endif
 
   void
   Allocate(size_t bufferSize)
@@ -134,11 +130,7 @@ public:
   using ModifiedTimeType = unsigned long;
 
   itkNewMacro(Self);
-#ifdef itkOverrideGetNameOfClassMacro
   itkOverrideGetNameOfClassMacro(CudaDataManager);
-#else
-  itkTypeMacro(CudaDataManager, Object);
-#endif
 
   /** total buffer size in bytes */
   void

--- a/include/itkCudaDataManager.h
+++ b/include/itkCudaDataManager.h
@@ -27,7 +27,7 @@
 #include <mutex>
 #include <memory>
 
-//#define VERBOSE
+// #define VERBOSE
 
 namespace itk
 {

--- a/include/itkCudaImage.h
+++ b/include/itkCudaImage.h
@@ -104,9 +104,11 @@ public:
   TPixel &
   GetPixel(const IndexType & index);
 
-  const TPixel & operator[](const IndexType & index) const;
+  const TPixel &
+  operator[](const IndexType & index) const;
 
-  TPixel & operator[](const IndexType & index);
+  TPixel &
+  operator[](const IndexType & index);
 
   /** Explicit synchronize CPU/Cuda buffers */
   void

--- a/include/itkCudaImage.h
+++ b/include/itkCudaImage.h
@@ -48,11 +48,7 @@ public:
 
   itkNewMacro(Self);
 
-#ifdef itkOverrideGetNameOfClassMacro
   itkOverrideGetNameOfClassMacro(CudaImage);
-#else
-  itkTypeMacro(CudaImage, Image);
-#endif
 
   static constexpr unsigned int ImageDimension = VImageDimension;
 
@@ -249,11 +245,7 @@ public:
   itkFactorylessNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-#ifdef itkOverrideGetNameOfClassMacro
   itkOverrideGetNameOfClassMacro(CudaImageFactory);
-#else
-  itkTypeMacro(CudaImageFactory, itk::ObjectFactoryBase);
-#endif
 
   /** Register one factory of this type  */
   static void

--- a/include/itkCudaImage.hxx
+++ b/include/itkCudaImage.hxx
@@ -132,14 +132,16 @@ CudaImage<TPixel, VImageDimension>::GetPixel(const IndexType & index)
 }
 
 template <class TPixel, unsigned int VImageDimension>
-TPixel & CudaImage<TPixel, VImageDimension>::operator[](const IndexType & index)
+TPixel &
+CudaImage<TPixel, VImageDimension>::operator[](const IndexType & index)
 {
   m_DataManager->UpdateCPUBuffer();
   return Superclass::operator[](index);
 }
 
 template <class TPixel, unsigned int VImageDimension>
-const TPixel & CudaImage<TPixel, VImageDimension>::operator[](const IndexType & index) const
+const TPixel &
+CudaImage<TPixel, VImageDimension>::operator[](const IndexType & index) const
 {
   m_DataManager->UpdateCPUBuffer();
   return Superclass::operator[](index);

--- a/include/itkCudaImageDataManager.h
+++ b/include/itkCudaImageDataManager.h
@@ -48,11 +48,7 @@ public:
   using SizeType = typename ImageType::SizeType;
 
   itkNewMacro(Self);
-#ifdef itkOverrideGetNameOfClassMacro
   itkOverrideGetNameOfClassMacro(CudaImageDataManager);
-#else
-  itkTypeMacro(CudaImageDataManager, CudaDataManager);
-#endif
 
   itkGetModifiableObjectMacro(GPUBufferedRegionIndex, CudaDataManager);
   itkGetModifiableObjectMacro(GPUBufferedRegionSize, CudaDataManager);

--- a/include/itkCudaImageDataManager.hxx
+++ b/include/itkCudaImageDataManager.hxx
@@ -19,7 +19,7 @@
 #define itkCudaImageDataManager_hxx
 
 #include "itkCudaUtil.h"
-//#define VERBOSE
+// #define VERBOSE
 
 namespace itk
 {

--- a/include/itkCudaImageToImageFilter.h
+++ b/include/itkCudaImageToImageFilter.h
@@ -51,11 +51,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-#ifdef itkOverrideGetNameOfClassMacro
   itkOverrideGetNameOfClassMacro(CudaImageToImageFilter);
-#else
-  itkTypeMacro(CudaImageToImageFilter, TParentImageFilter);
-#endif
 
   /** Superclass type alias. */
   using DataObjectIdentifierType = typename Superclass::DataObjectIdentifierType;

--- a/include/itkCudaInPlaceImageFilter.h
+++ b/include/itkCudaInPlaceImageFilter.h
@@ -47,11 +47,7 @@ public:
   using ConstPointer = SmartPointer<const Self>;
 
   /** Run-time type information (and related methods). */
-#ifdef itkOverrideGetNameOfClassMacro
   itkOverrideGetNameOfClassMacro(CudaInPlaceImageFilter);
-#else
-  itkTypeMacro(CudaInPlaceImageFilter, CudaImageToImageFilter);
-#endif
 
   /** Superclass type alias. */
   using OutputImageType = typename GPUSuperclass::OutputImageType;

--- a/include/itkCudaSquareImageFilter.h
+++ b/include/itkCudaSquareImageFilter.h
@@ -52,9 +52,7 @@ public:
   /** ImageDimension constants */
   static constexpr unsigned int ImageDimension = TImage::ImageDimension;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
   itkConceptMacro(ImageDimensionCheck, (itk::Concept::SameDimensionOrMinusOneOrTwo<3, TImage::ImageDimension>));
-#endif
 
 protected:
   CudaSquareImageFilter() = default;

--- a/include/itkCudaSquareImageFilter.h
+++ b/include/itkCudaSquareImageFilter.h
@@ -58,13 +58,14 @@ protected:
   CudaSquareImageFilter() = default;
   ~CudaSquareImageFilter() = default;
 
-  virtual void GPUGenerateData();
+  virtual void
+  GPUGenerateData();
 };
 
 } // end namespace itk
 
 #ifndef ITK_MANUAL_INSTANTIATION
-#include "itkCudaSquareImageFilter.hxx"
+#  include "itkCudaSquareImageFilter.hxx"
 #endif
 
 #endif

--- a/include/itkCudaSquareImageFilter.h
+++ b/include/itkCudaSquareImageFilter.h
@@ -45,11 +45,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-#ifdef itkOverrideGetNameOfClassMacro
   itkOverrideGetNameOfClassMacro(CudaSquareImageFilter);
-#else
-  itkTypeMacro(CudaSquareImageFilter, CudaImageToImageFilter);
-#endif
 
   ITK_DISALLOW_COPY_AND_MOVE(CudaSquareImageFilter);
 

--- a/include/itkCudaSquareImageFilter.hxx
+++ b/include/itkCudaSquareImageFilter.hxx
@@ -22,20 +22,23 @@
 
 namespace itk
 {
-  template <class ImageType>
-  void CudaSquareImageFilter<ImageType>::GPUGenerateData()
+template <class ImageType>
+void
+CudaSquareImageFilter<ImageType>::GPUGenerateData()
+{
+  int size[3] = { 1, 1, 1 };
+  for (unsigned int i = 0; i < ImageDimension; i++)
   {
-    int size[3] = {1, 1, 1};
-    for (unsigned int i = 0; i < ImageDimension; i++)
-    {
-      size[i] = this->GetInput()->GetBufferedRegion().GetSize()[i];
-    }
-
-    typename ImageType::PixelType* pin0 = *(typename ImageType::PixelType**)(this->GetInput(0)->GetCudaDataManager()->GetGPUBufferPointer());
-    typename ImageType::PixelType* pout = *(typename ImageType::PixelType**)(this->GetOutput()->GetCudaDataManager()->GetGPUBufferPointer());
-
-    CudaSquareImage3D<typename ImageType::PixelType>(size, pin0, pout);
+    size[i] = this->GetInput()->GetBufferedRegion().GetSize()[i];
   }
+
+  typename ImageType::PixelType * pin0 =
+    *(typename ImageType::PixelType **)(this->GetInput(0)->GetCudaDataManager()->GetGPUBufferPointer());
+  typename ImageType::PixelType * pout =
+    *(typename ImageType::PixelType **)(this->GetOutput()->GetCudaDataManager()->GetGPUBufferPointer());
+
+  CudaSquareImage3D<typename ImageType::PixelType>(size, pin0, pout);
+}
 
 } // end namespace itk
 

--- a/include/itkCudaUtil.h
+++ b/include/itkCudaUtil.h
@@ -69,10 +69,10 @@ CudaSelectPlatform(const char * name);
 
 /** Check Cuda error */
 void CudaCommon_EXPORT
-     CudaCheckError(cudaError_t error, const char * filename = "", int lineno = 0, const char * location = "");
+CudaCheckError(cudaError_t error, const char * filename = "", int lineno = 0, const char * location = "");
 
 void CudaCommon_EXPORT
-     CudaCheckError(CUresult error, const char * filename = "", int lineno = 0, const char * location = "");
+CudaCheckError(CUresult error, const char * filename = "", int lineno = 0, const char * location = "");
 
 /** Check if Cuda-enabled Cuda is present. */
 bool

--- a/src/itkCudaDataManager.cxx
+++ b/src/itkCudaDataManager.cxx
@@ -43,10 +43,7 @@ CudaDataManager::CudaDataManager()
   }
 }
 
-CudaDataManager::~CudaDataManager()
-{
-  m_GPUBuffer = nullptr;
-}
+CudaDataManager::~CudaDataManager() { m_GPUBuffer = nullptr; }
 
 void
 CudaDataManager::SetBufferSize(size_t num)

--- a/test/itkCudaSquareImageFilterTest.cxx
+++ b/test/itkCudaSquareImageFilterTest.cxx
@@ -1,20 +1,20 @@
 /*=========================================================================
-*
-*  Copyright Insight Software Consortium
-*
-*  Licensed under the Apache License, Version 2.0 (the "License");
-*  you may not use this file except in compliance with the License.
-*  You may obtain a copy of the License at
-*
-*         https://www.apache.org/licenses/LICENSE-2.0.txt
-*
-*  Unless required by applicable law or agreed to in writing, software
-*  distributed under the License is distributed on an "AS IS" BASIS,
-*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-*  See the License for the specific language governing permissions and
-*  limitations under the License.
-*
-*=========================================================================*/
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
 
 /**
  * Test program for itkCudaImage class.
@@ -25,7 +25,8 @@
 
 using ItkImage2f = itk::CudaImage<float, 2>;
 
-int itkCudaSquareImageFilterTest(int, char*[])
+int
+itkCudaSquareImageFilterTest(int, char *[])
 {
   unsigned int width, height;
   width = 256;
@@ -51,8 +52,7 @@ int itkCudaSquareImageFilterTest(int, char*[])
   src->Allocate();
   src->FillBuffer(fillValue);
 
-  itk::CudaSquareImageFilter<ItkImage2f>::Pointer sqImageFilter =
-    itk::CudaSquareImageFilter<ItkImage2f>::New();
+  itk::CudaSquareImageFilter<ItkImage2f>::Pointer sqImageFilter = itk::CudaSquareImageFilter<ItkImage2f>::New();
   sqImageFilter->SetInput(src);
   sqImageFilter->Update();
 


### PR DESCRIPTION
The macros, introduced by dcc34017262901c98c769aef3a8abfd2d9923b77, are no longer required as ITK has been released since and we only maintain compatibility with the latest ITK release and the master's head.

Supersedes and closes #44.