### PR TITLE
COMP: Replace deprecated itkTypeMacro with itkOverrideGetNameOfClassMacro

### DIFF
--- a/include/itkCudaImageFromImageFilter.h
+++ b/include/itkCudaImageFromImageFilter.h
@@ -50,7 +50,7 @@ public:
   using ConstPointer = SmartPointer<const Self>;
 
   itkNewMacro(Self);
-  itkTypeMacro(CudaImageFromImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(CudaImageFromImageFilter);
 
 protected:
   CudaImageFromImageFilter() = default;


### PR DESCRIPTION
itkTypeMacro does not compile with ITK_FUTURE_LEGACY_REMOVE ON since v5.4.