### PR TITLE
BUG: Fix generated itkCudaCommonConfiguration.h path for installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,6 @@ endif()
 # Install configuration file
 install(
   FILES
-    ${CudaCommon_BINARY_DIR}/include/itkCudaCommonConfiguration.h
+    ${_configuration_header_file}
   DESTINATION ${CudaCommon_INSTALL_INCLUDE_DIR}
 )


### PR DESCRIPTION
This bug was introduced by the previous commit, see 6feb4a7eb5a7db6dd462bfbcd14c7d8964dc1597 for more details.