### PR TITLE
COMP: Fix cmake option for CUDACOMMON_CUDA_VERSION

### DIFF
--- a/itk-module-init.cmake
+++ b/itk-module-init.cmake
@@ -29,14 +29,27 @@ if(CMAKE_CUDA_COMPILER)
 endif()
 
 # Configure CUDA compilation options
-option(
-  CUDACOMMON_CUDA_VERSION
-  "Specify the exact CUDA version that must be used for CudaCommon"
-)
+if(NOT CUDACOMMON_CUDA_VERSION)
+  set(
+    CUDACOMMON_CUDA_VERSION
+    ${CUDAToolkit_VERSION}
+    CACHE STRING
+    "Specify the exact CUDA version that must be used for CudaCommon"
+  )
+else()
+  set(
+    CUDACOMMON_CUDA_VERSION
+    ${CUDACOMMON_CUDA_VERSION}
+    CACHE STRING
+    "Specify the exact CUDA version that must be used for CudaCommon"
+  )
+endif()
+mark_as_advanced(CUDACOMMON_CUDA_VERSION)
+
 if(CUDAToolkit_FOUND)
   enable_language(CUDA)
   set(CMAKE_CUDA_RUNTIME_LIBRARY Static)
   if(CUDACOMMON_CUDA_VERSION)
-    find_package(CUDAToolkit EXACT ${CUDACOMMON_CUDA_VERSION})
+    find_package(CUDAToolkit EXACT ${CUDACOMMON_CUDA_VERSION} REQUIRED)
   endif()
 endif()


### PR DESCRIPTION
CMake "option" only allows boolean ON|OFF values to be set as cmake CACHE variables.  The
value of CUDACOMMON_CUDA_VERSION is expected to be a VERSION string like 12.9 or 11.2 which is not
compatible with the cmake "option".

The subsequent
find_package(CUDAToolkit EXACT ${CUDACOMMON_CUDA_VERSION})

Requires the value after EXACT to be a valid version string (i.e. ON or OFF are invalid choices).

If not set from the command line, default the value of CUDACOMMON_CUDA_VERSION to the version that was previously found.