### PR TITLE
ENH: Remove build on cuda 128 and 130 for manylinux2014

### DIFF
--- a/.github/workflows/build-test-package-python-cuda.yml
+++ b/.github/workflows/build-test-package-python-cuda.yml
@@ -19,7 +19,12 @@ jobs:
       matrix:
         python3-minor-version: ${{ github.event_name == 'pull_request' && fromJSON('["11"]') || fromJSON('["9","10","11"]') }}
         manylinux-platform: ["_2_28-x64","2014-x64"]
-        cuda-version: ["118","128","130"]
+        cuda-version: ["118","124","128","130"]
+        exclude:
+          - manylinux-platform: "2014-x64"
+            cuda-version: "128"
+          - manylinux-platform: "2014-x64"
+            cuda-version: "130"
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Manylinux2014 is not compatible with recent version of cuda