### PR TITLE
ENH: Avoid repeated CUDA device selection queries

### DIFF
--- a/include/itkCudaUtil.h
+++ b/include/itkCudaUtil.h
@@ -55,7 +55,7 @@ GetCudaComputeCapability(int device);
 int
 CudaGetAvailableDevices(std::vector<cudaDeviceProp> & devices);
 
-/** Get the device that has the maximum FLOPS in the current context */
+/** Get the device that has the maximum FLOPS in the current context. The result is cached for future calls. */
 int
 CudaGetMaxFlopsDev();
 

--- a/src/itkCudaUtil.cxx
+++ b/src/itkCudaUtil.cxx
@@ -69,18 +69,19 @@ CudaGetAvailableDevices(std::vector<cudaDeviceProp> & devices)
 }
 
 //
-// Get the device that has the maximum FLOPS
+// Compute the device that has the maximum FLOPS
 //
 int
-CudaGetMaxFlopsDev()
+ComputeMaxFlopsDevice()
 {
   std::vector<cudaDeviceProp> devices;
   int                         numAvailableDevices = CudaGetAvailableDevices(devices);
+
   if (numAvailableDevices == 0)
   {
-
     return -1;
   }
+
   int max_flops = 0;
   int max_flops_device = 0;
   for (int i = 0; i < numAvailableDevices; ++i)
@@ -94,6 +95,14 @@ CudaGetMaxFlopsDev()
       max_flops_device = i;
     }
   }
+
+  return max_flops_device;
+}
+
+int
+CudaGetMaxFlopsDev()
+{
+  static const int max_flops_device = ComputeMaxFlopsDevice();
 
   return max_flops_device;
 }


### PR DESCRIPTION
CudaDataManager calls CudaGetMaxFlopsDev during construction, so iterative pipelines can repeatedly query CUDA device properties when many temporary CUDA images or filters are created.

Compute the max-FLOPS device once with function-local static initialization and reuse the selected device for subsequent CudaGetMaxFlopsDev calls.

This avoids repeated cudaGetDeviceProperties and cudaDeviceGetAttribute